### PR TITLE
Integrate with customer account

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,15 @@ The example below removes the `/account` prefix from the login, register and res
 /account/activate > /activate-account
 ```
 
+## Customer accounts integration
+
+You can integrate with [customer accounts](https://help.shopify.com/en/manual/customers/customer-accounts/new-customer-accounts) by enabling it in **Theme settings > Integrate with customer accounts**.
+
+This will add query params to the redirect URL based on the situation:
+
+- `logged_in=true`: Present only if the customer has logged in. You can use this value to initiate a [login](https://shopify.dev/docs/api/hydrogen/2024-01/utilities/createcustomeraccountclient#returns-propertydetail-login) that should be transparent to the customer.
+- `company_location_id=<id>`: Present only if your store is B2B-enabled, a B2B customer has logged in, and has selected a location. Your storefront should still confirm whether the customer has access to this location through the Customer Account API.
+
 ## Gift cards
 
 Since the Shopify Storefront API does not yet support fetching gift cards, a customizable `gift_card.liquid` template has been added.

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -25,6 +25,12 @@
         "id": "custom_redirects",
         "label": "Custom redirects",
         "info": "Shopify path > Storefront path [Learn more](https://github.com/Shopify/hydrogen-redirect-theme#custom-redirects)"
+      },
+      {
+        "type": "checkbox",
+        "id": "integrate_with_customer_accounts",
+        "label": "Integrate with customer accounts",
+        "info": " [Learn more](https://help.shopify.com/en/manual/customers/customer-accounts/new-customer-accounts)"
       }
     ]
   }

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -42,7 +42,7 @@
         }
 
         if (
-          !window.Shopify.designMode && 
+          !window.Shopify.designMode &&
             window.location.pathname !== '/checkpoint' &&
             window.location.pathname !== '/throttle/queue' &&
             window.location.pathname !== '/challenge'
@@ -70,6 +70,14 @@
             }
 
             redirectUrl = new URL(redirectUrl);
+
+            {%- if settings.integrate_with_customer_accounts and customer != null -%}
+              redirectUrl.searchParams.append('logged_in', 'true');
+
+              {%- if customer.current_location != null -%}
+                redirectUrl.searchParams.append('company_location_id', '{{ customer.current_location.id }}');
+              {%- endif -%}
+            {%- endif -%}
 
             {% comment %}
               Handle discount code logic (e.g. xxx.myshopify.com/discount/freeshipping?redirect=/products)


### PR DESCRIPTION
Added a new option to integrate with customer accounts. When enabled, it adds the `logged_in=true` and `company_location_id=<id>` query params to the redirect URL when the customer is authenticated.