### PR TITLE
Change name wordpress redirect theme

### DIFF
--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "theme_info",
-    "theme_name": "WordPress Redirect",
+    "theme_name": "WordPress",
     "theme_author": "Shopify",
     "theme_version": "1.0.0",
     "theme_documentation_url": "https://help.shopify.com/manual/online-sales-channels/wordpress/manage-checkout-traffic#wordpress-theme",


### PR DESCRIPTION
Simply make it `WordPress`