### PR TITLE
Fix redirect link to work properly in design mode with vibe platforms

### DIFF
--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -151,7 +151,7 @@
         {%- if settings.storefront_hostname != blank -%}
           <h1>Redirecting...</h1>
           <p>
-            <a id="redirect-link" href="https://{{ settings.storefront_hostname }}/">Click here</a>
+            <a id="redirect-link" href="https://{{ settings.storefront_hostname }}">Click here</a>
             if you are not automically redirected.
           </p>
           <script>


### PR DESCRIPTION
Pretty straightforward, in design mode the code to update the link to match the correct redirect / pathname doesn't run, but we can simply leave off the trailing slash in the template.