### PR TITLE
Add favicon setting to redirect theme for Shopify checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ detection checkpoint, and discount links.
 5. Go to **Theme settings -> Storefront** and configure `storefront_hostname`
 6. **Publish** the theme
 
+## Favicon
+
+You can configure the `favicon` value in **Theme settings -> Logo**.
+
+The favicon is used on `/checkouts/` urls (and any unredirected online store urls)
+
 ## Custom redirects
 
 You can configure the `custom_redirects` value in **Theme settings > Storefront**.

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -8,6 +8,17 @@
     "theme_support_url": "https://github.com/Shopify/hydrogen-redirect-theme/issues"
   },
   {
+    "name": "Logo",
+    "settings": [
+      {
+        "type": "image_picker",
+        "id": "favicon",
+        "label": "Favicon",
+        "info": "Displayed at 32 x 32px"
+      }
+    ]
+  },
+  {
     "name": "Storefront",
     "settings": [
       {


### PR DESCRIPTION
Shopify Checkout automatically uses the favicon configured in a theme’s settings. This is implicit/undocumented behavior, but it affects the favicon shown at checkout.

This PR adds the missing favicon setting to the redirect theme so we can set a custom favicon and maintain trust + visual continuity when users are redirected from the Hydrogen storefront to Checkout.