### PR TITLE
Improve redirect routing to not route unconfigured paths

### DIFF
--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -54,9 +54,14 @@
           );
 
           if (currentUrl.hostname !== storefrontUrl.hostname) {
-            var redirectUrl = new URL(currentUrl);
-            redirectUrl.hostname = storefrontUrl.hostname;
+            var redirectUrl = new URL(storefrontUrl);
+            redirectUrl.search = '';
+
             // Merge search params from both currentUrl and storefrontUrl
+            currentUrl.searchParams.forEach(function(value, key) {
+              redirectUrl.searchParams.append(key, value);
+            });
+
             storefrontUrl.searchParams.forEach(function(value, key) {
               redirectUrl.searchParams.append(key, value);
             });
@@ -70,8 +75,8 @@
                 var fromPath = redirect[0];
                 var toPath = redirect[1];
 
-                if (fromPath && toPath && redirectUrl.pathname.startsWith(fromPath)) {
-                  redirectUrl.pathname = redirectUrl.pathname.replace(fromPath, toPath);
+                if (fromPath && toPath && currentUrl.pathname.startsWith(fromPath)) {
+                  redirectUrl.pathname = currentUrl.pathname.replace(fromPath, toPath);
                   break;
                 }
               }


### PR DESCRIPTION
### Summary

This updates redirect URL construction so Shopify-specific paths are not carried over to the Hydrogen storefront by default.

Previously, the redirect URL was cloned from the current Shopify URL and only the hostname was replaced. That meant routes like /password were appended to the Hydrogen storefront URL, often causing a 404 when the Hydrogen app does not implement those Shopify-specific paths.

The redirect now starts from the configured storefront URL instead. Current request query params and configured storefront query params are still preserved, while custom redirect rules continue to rewrite matching source paths explicitly.

### Details

- Prevents Shopify-specific paths like /password from being appended to the Hydrogen redirect URL by default.
- Preserves existing query parameter behavior from both the current request and storefront_hostname.
- Keeps custom redirects working by matching rules against the original current pathname.
- Allows configured storefront base paths to remain authoritative.